### PR TITLE
Fix LLM filter merging

### DIFF
--- a/src/mcp/clinical_trial_mcp_server.py
+++ b/src/mcp/clinical_trial_mcp_server.py
@@ -535,7 +535,8 @@ class ClinicalTrialMCPServer:
         """Perform the actual search operation using AI-driven query understanding"""
         # Use AI to parse the natural language query
         if query:
-            ai_filters = await self._parse_natural_language_query(query)
+            ai_result = await self._parse_natural_language_query(query)
+            ai_filters = ai_result.get("filters", {})
             # Merge AI-generated filters with explicit filters
             search_filters = {**ai_filters, **filters}
         else:
@@ -586,7 +587,8 @@ class ClinicalTrialMCPServer:
         format_type = arguments.get("format", "table")
         try:
             # Parse natural language query
-            filters = await self._parse_natural_language_query(query)
+            ai_result = await self._parse_natural_language_query(query)
+            filters = ai_result.get("filters", {})
             # Perform search
             results = self.db.search_trials(filters, limit)
             if not results:

--- a/tests/test_filter_application.py
+++ b/tests/test_filter_application.py
@@ -1,0 +1,34 @@
+import asyncio
+import pytest
+import sys
+from pathlib import Path
+
+src_dir = Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(src_dir))
+
+from mcp.clinical_trial_mcp_server import ClinicalTrialMCPServer
+
+class DummyDB:
+    def __init__(self):
+        self.received_filters = None
+    def search_trials(self, filters, limit):
+        self.received_filters = filters
+        return []
+
+def make_server():
+    server = ClinicalTrialMCPServer.__new__(ClinicalTrialMCPServer)
+    server.db = DummyDB()
+    return server
+
+@pytest.mark.asyncio
+async def test_perform_search_uses_llm_filters():
+    server = make_server()
+
+    async def fake_parse(query):
+        return {"filters": {"indication": ["diabetes"]}}
+
+    server._parse_natural_language_query = fake_parse
+
+    await server._perform_search("find diabetes", {"trial_phase": "PHASE3"}, 10)
+
+    assert server.db.received_filters == {"indication": ["diabetes"], "trial_phase": "PHASE3"}


### PR DESCRIPTION
## Summary
- ensure that only the `filters` dict from the LLM result is merged with user filters
- cover `_perform_search` behaviour with unit test

## Testing
- `python -m pytest tests/test_filter_application.py -q`
- `python -m pytest -q` *(fails: async tests require OPENAI API access)*

------
https://chatgpt.com/codex/tasks/task_e_68820861611c83329154ee41a5be089d