### PR TITLE
Fix async markers in enhanced query tests

### DIFF
--- a/tests/test_enhanced_query_processing.py
+++ b/tests/test_enhanced_query_processing.py
@@ -22,6 +22,10 @@ from mcp.clinical_trial_mcp_server import ClinicalTrialMCPServer
 from analysis.clinical_trial_analyzer_reasoning import ClinicalTrialAnalyzerReasoning
 
 
+import pytest
+
+
+@pytest.mark.asyncio
 async def test_enhanced_query_processing():
     """Test the enhanced LLM-based query processing"""
 
@@ -226,6 +230,7 @@ async def test_enhanced_query_processing():
         return False
 
 
+@pytest.mark.asyncio
 async def test_fallback_processing():
     """Test the enhanced fallback processing when LLM is not available"""
 


### PR DESCRIPTION
## Summary
- fix pytest markers for async tests

## Testing
- `pytest tests/test_filter_application.py::test_perform_search_uses_llm_filters -q`
- `pytest tests/test_enhanced_query_processing.py::test_enhanced_query_processing -q`
- `pytest tests/test_enhanced_query_processing.py::test_fallback_processing -q`


------
https://chatgpt.com/codex/tasks/task_e_6882391afe0c83329206e4993070fa64